### PR TITLE
Try Fix Orientation of Images Shot on iPhone

### DIFF
--- a/Pick Color/PickColorViewController.swift
+++ b/Pick Color/PickColorViewController.swift
@@ -26,19 +26,29 @@ class PickColorViewController: UIViewController, UINavigationControllerDelegate,
     fileprivate var pixelData = PixelData()
     fileprivate var pan: UIPanGestureRecognizer? = nil
     fileprivate var image: UIImage? {
-        willSet {
-            if let image = newValue {
+        didSet {
+            if let rawIamge = image {
                 if (pan != nil) {
                     view.removeGestureRecognizer(pan!)
                 }
+                
+                if rawIamge.imageOrientation == .up {
+                    image = rawIamge
+                } else {
+                    UIGraphicsBeginImageContextWithOptions(rawIamge.size, false, rawIamge.scale)
+                    defer { UIGraphicsEndImageContext() }
+                    rawIamge.draw(in: CGRect(origin: .zero, size: rawIamge.size))
+                    image = UIGraphicsGetImageFromCurrentImageContext()
+                }
+                
                 view.sendSubview(toBack: selectImageButton)
                 selectImageButton.isHidden = true
                 imageView.image = image
-                pixelData.image = image.cgImage
+                pixelData.image = image!.cgImage
                 imageView.model = pixelData
-                let scale = view.frame.height / image.size.height
-                heightOfImageView.constant = image.size.height * scale
-                widthOfImageView.constant = image.size.width * scale
+                let scale = view.frame.height / image!.size.height
+                heightOfImageView.constant = image!.size.height * scale
+                widthOfImageView.constant = image!.size.width * scale
                 centerXOfImageView.constant = 0
                 centerYOfImageView.constant = 0
                 updateManager()


### PR DESCRIPTION
No one would ever consider about EXIF. For more information, please refer to [this article for more](https://medium.com/%E5%BD%BC%E5%BE%97%E6%BD%98%E7%9A%84-swift-ios-app-%E9%96%8B%E7%99%BC%E5%95%8F%E9%A1%8C%E8%A7%A3%E7%AD%94%E9%9B%86/%E5%9C%A8-storyboard-image-view-%E8%A8%AD%E5%AE%9A%E7%9A%84%E5%9C%96%E7%89%87%E8%8E%AB%E5%90%8D%E6%97%8B%E8%BD%89%E4%BA%86-4b82503a8a1d).
This has been tested on iPad, NOT iPhone.
And also, could you please change device to `Universal` instead iPhone only?